### PR TITLE
Add connection pool clearing for dead connections

### DIFF
--- a/lib/sneakers_toolbox/lost_db_connection_handler.rb
+++ b/lib/sneakers_toolbox/lost_db_connection_handler.rb
@@ -1,0 +1,23 @@
+module SneakersToolbox
+  # Clears dead connections from ActiveRecord connection pool
+  #
+  # It sometimes happens when using Amazon RDS over QuotaGuard tunnel, that a
+  # DB connection is lost but Rails still keeps it in the connection pool
+  #
+  # This results in StatementInvalid errors and service outage - because
+  # eventually the pool can get filled with these dead connections that Rails
+  # thinks are still alive.
+  #
+  # This method solves it by rescuing the "ActiveRecord::StatementInvalid" and
+  # clearing active connections, thus forcing rails to re-establish them.
+  class LostDbConnectionHandler
+    def self.with_connection
+      ActiveRecord::Base.connection_pool.with_connection { yield }
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error("Cleaning active connections after exception: #{e}")
+      ActiveRecord::Base.clear_active_connections!
+
+      raise e
+    end
+  end
+end


### PR DESCRIPTION
LostDbConnectionHandler gets around the case when connecting to Postgres
(or possibly other DB-s) throgh Quota Guard and non-working connections
end up in ActiveRecord's connection pool.