### PR TITLE
Add Ticktock worker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.5.0-node-browsers
+       - image: circleci/ruby:2.6.1-node-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -22,10 +22,11 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v2-dependencies-{{ checksum "sneakers_toolbox.gemspec" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
 
+      - run: gem install bundler -v '2.0.1'
       - run:
           name: install dependencies
           command: |
@@ -34,7 +35,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v2-dependencies-{{ checksum "sneakers_toolbox.gemspec" }}
 
       # run tests!
       - run:

--- a/lib/sneakers_toolbox.rb
+++ b/lib/sneakers_toolbox.rb
@@ -1,5 +1,6 @@
 require "sneakers_toolbox/version"
 require 'sneakers_toolbox/lost_db_connection_handler'
+require 'sneakers_toolbox/ticktock_worker'
 
 module SneakersToolbox
   def self.logger

--- a/lib/sneakers_toolbox/sneakers_timer.rb
+++ b/lib/sneakers_toolbox/sneakers_timer.rb
@@ -1,0 +1,10 @@
+# Integrates seamlessly with https://github.com/librato/librato-logreporter when defined
+class SneakersTimer
+  def self.timing(worker_class)
+    if defined?(Librato) && Librato.respond_to?(:timing)
+      Librato.timing("sneakers_worker.timing.#{worker_class}") { yield }
+    else
+      yield
+    end
+  end
+end

--- a/lib/sneakers_toolbox/ticktock_worker.rb
+++ b/lib/sneakers_toolbox/ticktock_worker.rb
@@ -1,0 +1,92 @@
+require 'sneakers_handlers'
+require_relative './worker_timeout_error'
+require_relative './sneakers_timer'
+
+# This is a helper module that should be used to create workers that are
+# executed periodically, using `ticktock` (https://github.com/alphasights/ticktock).
+#
+# Usage:
+#
+# class MyWorker
+#   include TicktockWorker
+#
+#   configure queue: pistachio.my_queue_name,
+#             frequency: 1.minute,
+#             retry_on_failure: true # optional (default: false)
+
+#   def process_message
+#     # work
+#   end
+# end
+#
+# The values supported for the `frequency` configuration are the ones defined
+# by `ticktock`. This value should be an `ActiveSupport::Duration`, like
+# `5.seconds` or `24.hours`.
+#
+# These workers only need to return an `:ack` symbol if they are configured to
+# `retry_on_failure`, otherwise the message will be discarded as soon as it is
+# consumed.
+#
+module SneakersToolbox
+  module TicktockWorker
+    def self.included(base)
+      base.include(Sneakers::Worker)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+
+      # @param queue [String] The queue name
+      #
+      # @param frequency [ActiveSupport::Duration] A frequency supported by ticktock, like `1.minute`
+      #
+      # @param retry_on_failure [Boolean] Defines if the worker will use the
+      #   `RetryHandler`, in which case it needs to return an `:ack symbol`
+      def configure(queue:, frequency:, retry_on_failure: false, **other_properties)
+        sufix = frequency.inspect.gsub(' ', '-')
+        exchange_name = "ticktock.#{sufix}"
+
+        queue_properties =  {
+          durable: false,
+          exchange: exchange_name,
+          exchange_type: :fanout,
+          workers: 1,
+          threads: 1
+        }.merge(other_properties)
+
+        if retry_on_failure
+          queue_properties = queue_properties.merge({
+            ack: true,
+            handler: SneakersHandlers::RetryHandler,
+            max_retry: 5,
+            arguments: { "x-dead-letter-exchange" => "#{exchange_name}.dlx",
+                         "x-dead-letter-routing-key" => queue }
+          })
+        else
+          queue_properties = queue_properties.merge({
+            ack: false,
+          })
+        end
+
+        from_queue(queue, queue_properties)
+      end
+    end
+
+    def work(*args)
+      SneakersTimer.timing(self.class) do
+        LostDbConnectionHandler.with_connection do
+          response = process_message
+
+          MonitoredScheduledTask.ping(name: self.class.queue_name)
+          response
+        end
+      end
+    rescue Timeout::Error => e
+      Honeybadger.notify(WorkerTimeoutError.new(self.class))
+      raise e
+    rescue StandardError => e
+      Honeybadger.notify(e)
+      raise e
+    end
+  end
+end

--- a/lib/sneakers_toolbox/worker_timeout_error.rb
+++ b/lib/sneakers_toolbox/worker_timeout_error.rb
@@ -1,0 +1,16 @@
+module SneakersToolbox
+  class WorkerTimeoutError < StandardError
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def to_s
+      message
+    end
+
+    def message
+      timeout = @klass.queue_opts[:timeout_job_after] || Sneakers::CONFIG[:timeout_job_after]
+      "Worker '#{@klass.name}' timed out after #{timeout} seconds."
+    end
+  end
+end

--- a/sneakers_toolbox.gemspec
+++ b/sneakers_toolbox.gemspec
@@ -31,11 +31,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_dependency 'sneakers_handlers'
+
+  spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'activerecord'
+  spec.add_development_dependency 'sneakers'
   spec.add_development_dependency 'pry'
 end

--- a/spec/sneakers_toolbox/ticktock_worker_spec.rb
+++ b/spec/sneakers_toolbox/ticktock_worker_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+require 'sneakers'
+require_relative '../../lib/sneakers_toolbox'
+require 'active_support/core_ext/numeric/time'
+require 'json'
+require 'sqlite3'
+require 'active_record'
+
+RSpec.describe SneakersToolbox::TicktockWorker do
+  TicktockWorker = SneakersToolbox::TicktockWorker
+
+  it "configures queue with given parameters" do
+    queue_opts = Class.new do
+      include TicktockWorker
+      configure queue: "queue-name", frequency: 1.minute
+    end.queue_opts
+
+    expect(queue_opts[:durable]).to eql(false)
+    expect(queue_opts[:ack]).to eql(false)
+    expect(queue_opts[:exchange]).to eql("ticktock.1-minute")
+    expect(queue_opts[:exchange_type]).to eql(:fanout)
+    expect(queue_opts[:handler]).to be_nil
+  end
+
+  it "configures queue with retry handler" do
+    queue_opts = Class.new do
+      include TicktockWorker
+      configure queue: "queue-name", frequency: 5.seconds, retry_on_failure: true
+    end.queue_opts
+
+    expect(queue_opts[:durable]).to eql(false)
+    expect(queue_opts[:ack]).to eql(true)
+    expect(queue_opts[:exchange]).to eql("ticktock.5-seconds")
+    expect(queue_opts[:exchange_type]).to eql(:fanout)
+    expect(queue_opts[:handler]).to eql(SneakersHandlers::RetryHandler)
+    expect(queue_opts[:max_retry]).to eql(5)
+    expect(queue_opts[:arguments]).to eql({
+      "x-dead-letter-exchange" => "ticktock.5-seconds.dlx",
+      "x-dead-letter-routing-key" => "queue-name"
+    })
+  end
+
+  it "raises custom timeout error" do
+    ActiveRecord::Base.establish_connection({adapter: 'sqlite3', database: ':memory:'})
+    worker = Class.new do
+      include TicktockWorker
+
+      configure queue: "queue-name",
+                frequency: 1.minute,
+                ack: true
+
+      def process_message
+        raise Timeout::Error
+      end
+    end.new
+
+    mock_honeybadger = double('Honeybadger')
+    stub_const('Honeybadger', mock_honeybadger)
+    expect {
+      expect(mock_honeybadger).to receive(:notify).with(SneakersToolbox::WorkerTimeoutError.new(worker.class))
+      worker.work({}.to_json)
+    }.to raise_error(Timeout::Error)
+  end
+end


### PR DESCRIPTION
Migrated TickTock worker logic from pistachio. Originally written by
Brian Storti for pistachio. Reason from bringing it here is that the
need for TickTock worker has been popping up in multiple services and
copy-pasting this code can make us miss some improvements people add to
their apps. It is also true that centralising this logic can make it
more rigid - e.g. when designed badly it can make the reuse harder and
increase the chance that updating in one place can break another.

Current changes auto-detect presence of Librato and Honeybadger and send
messages to there if application that uses `sneakers_toolbox` has these
constants defined. More flexible approach would be to provide hooks
and/or dependency injection to allow SneakersWorker to notify the using
app when these events happen. Possibly providing example implementation
for `HoneybadgerNotifier` or `LibratoTimingNotifier` allowing the user
to go with reasonable defaults.