### PR TITLE
Make ticktock worker callbacks configurable

### DIFF
--- a/lib/sneakers_toolbox.rb
+++ b/lib/sneakers_toolbox.rb
@@ -1,8 +1,39 @@
 require "sneakers_toolbox/version"
 require 'sneakers_toolbox/lost_db_connection_handler'
 require 'sneakers_toolbox/ticktock_worker'
+require 'dry-configurable'
 
 module SneakersToolbox
+  extend Dry::Configurable
+  setting :ticktock do
+    # Allows to define callbacks for various exception classes for all Ticktock
+    # workers in one place
+    #
+    # To be assigned a Hash where key is subclass of StandardError and value is
+    # callable (its #call method will be called)
+    #
+    # Example use:
+    #
+    # SneakersToolbox.config.ticktock.error_callbacks = { MyError => Proc.new { notify_my_service } }
+    setting(:error_callbacks, {}) do |callbacks|
+      if callbacks.keys.all? { |k| k <= StandardError } && callbacks.values.all? { |v| v.respond_to?(:call) }
+        callbacks
+      else
+        raise ArgumentError, "error callbacks must have error as key and object with #call as value"
+      end
+    end
+
+    # Configure an object to be called after processing each message on every Ticktock worker
+    #
+    # This can be useful for notifying or pinging external services about the health of workers
+    # Example:
+    #
+    # SneakersToolbox::TicktockWorker
+    #   .after_work_callback = -> { MonitoredScheduledTask.ping(name: self.class.queue_name) }
+    #
+    setting :after_work_callback
+  end
+
   def self.logger
     if defined? Rails
       Rails.logger

--- a/sneakers_toolbox.gemspec
+++ b/sneakers_toolbox.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'sneakers_handlers'
+  spec.add_dependency 'dry-configurable'
 
   spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"


### PR DESCRIPTION
Previously after processing message or when error was raised during
processing of a message, there were explicit calls to Honeybadger and
MonitoredScheduledTask.

This change allows the same functionality to be used by configuring the
SneakersToolbox, freeing the user being bound to these constants being
defined or forcing checks for their presence in toolbox code.