### PR TITLE
Remove the release of all connections

### DIFF
--- a/lib/sneakers_toolbox/lost_db_connection_handler.rb
+++ b/lib/sneakers_toolbox/lost_db_connection_handler.rb
@@ -16,7 +16,6 @@ module SneakersToolbox
     rescue ActiveRecord::StatementInvalid => e
       SneakersToolbox.logger.error("Cleaning active connections after exception: #{e}")
       ActiveRecord::Base.clear_active_connections! # Returns connections to the pool
-      ActiveRecord::Base.clear_all_connections! # Disconnects them, forcing them to be re-established
       raise e
     end
   end


### PR DESCRIPTION
Removing the `clear_all_connections` call when `ActiveRecord::StatementInvalid` errors are thrown. Unfortunately this method has no description on the documentation, so we might avoid calling it and do exactly what Pistachio does.