### PR TITLE
Release new version for rails 7.1+

### DIFF
--- a/lib/sneakers_toolbox/lost_db_connection_handler.rb
+++ b/lib/sneakers_toolbox/lost_db_connection_handler.rb
@@ -15,7 +15,7 @@ module SneakersToolbox
       ActiveRecord::Base.connection_pool.with_connection { yield }
     rescue ActiveRecord::StatementInvalid => e
       SneakersToolbox.logger.error("Cleaning active connections after exception: #{e}")
-      ActiveRecord::Base.clear_active_connections! # Returns connections to the pool
+      ActiveRecord::Base.connection_handler.clear_active_connections! # Returns connections to the pool
       raise e
     end
   end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small compatibility change limited to error-recovery logic for ActiveRecord connection pooling; main risk is behavioral differences in how connections are cleared under Rails 7.1.
> 
> **Overview**
> Updates `LostDbConnectionHandler.with_connection` to clear active ActiveRecord connections via `ActiveRecord::Base.connection_handler.clear_active_connections!` instead of `ActiveRecord::Base.clear_active_connections!` when rescuing `ActiveRecord::StatementInvalid`, aligning the recovery path with Rails 7.1+ APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0f2399f7fb28f2081ebb3dc5eb8cb9c37ffc7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->